### PR TITLE
Added line in config that prevents future posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,3 +32,5 @@ collections:
   tutors:
     output: true
     title: Top Tutoring
+
+future: false


### PR DESCRIPTION
Currently, the future dated posts are being published. A config statment
had to be made to prevent future dated posts from being published. Added
line but unsure if this will be built again when the day comes around.