### PR TITLE
Fixed Meme Article Formatting

### DIFF
--- a/_posts/2017-07-21-How-Memes-Are-Unifying-the-Top-Universities.md
+++ b/_posts/2017-07-21-How-Memes-Are-Unifying-the-Top-Universities.md
@@ -10,6 +10,7 @@ author_link: /tutors/Zhimin.html
 ---
 
 A UC Berkeley student-governed meme page on Facebook called “UC Berkeley Memes for Edgy Teens” started out as a way for Cal students to relieve stress, but in 2016, it gained popularity outside of the university. Although UC Berkeley only has a 40,000 student population, the meme page has about 100,000 members. Shortly after, meme pages started popping up at many major universities, mostly in Ivy leagues and mini Ivy leagues like Stanford, Harvard, UCLA, USC, Duke, Yale, etc.
+<!--more-->
 
 ### Most of these pages have strict guidelines.
 


### PR DESCRIPTION
I fixed the formatting for the Meme Article by adding the "read more" feature so it shows a preview rather the entire article in blogs. By doing so, the title automatically became more bolded than the headings.
<img width="629" alt="screen shot 2017-07-30 at 7 50 37 am" src="https://user-images.githubusercontent.com/30183695/28754555-629aa206-74fc-11e7-8be9-84cd1696daa5.png">
<img width="610" alt="screen shot 2017-07-30 at 7 50 48 am" src="https://user-images.githubusercontent.com/30183695/28754556-646e279c-74fc-11e7-89a7-d770cf64e3fe.png">

