### PR TITLE
Changed erroneous class reference for buttons

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -126,6 +126,7 @@
 
 .btn-lg-blue:hover {
   background: #59a4f0;
+  color: #fff;
 }
 
 .btn-lg-blue:visited {
@@ -134,6 +135,7 @@
 
 .btn-sm-blue:hover {
   background: #59a4f0;
+  color: #fff;
 }
 
 .btn-sm-blue:visited {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@ permalink: /
                 <div class="row">
                     <div class="col-sm-12 text-center">
                         <h3 class="mb40 mb-xs-24">Find a Tutor&nbsp;</h3>
-                        <a class="btn btn-lg btn-filled btn-blue" href="{{ site.client_sign_up_url }}" target="_self">sign up</a>
+                        <a class="btn btn-lg" href="{{ site.client_sign_up_url }}" target="_self">sign up</a>
                     </div>
                 </div>
 


### PR DESCRIPTION
The index page buttons had a class of bn-blue when it shouldn't have.
Also the css for the btn-blue:hover classes didn't specify a change in
font color which made the text invisible. All this was changed in this
commit.

All buttons show properly as below. 
![screen shot 2017-08-17 at 1 13 08 pm](https://user-images.githubusercontent.com/24426214/29432232-b3702a32-834f-11e7-92bf-6a8c4c45ba6c.png)

As well as when hovered.
![screen shot 2017-08-17 at 1 13 20 pm](https://user-images.githubusercontent.com/24426214/29432235-b50791dc-834f-11e7-97e3-589fc47fbf01.png)
