### PR TITLE
Fix typo in subjects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ permalink: /
                     </div>
                     <ol class="breadcrumb breadcrumb-2">
                         <li>
-                            Here's a sampling of some of the subjects we currently offer<br>don't see your subject? contact us and we will try out best to find a tutor for you!<br>
+                            Here's a sampling of some of the subjects we currently offer<br>don't see your subject? contact us and we will try our best to find a tutor for you!<br>
                         </li>
                     </ol>
                 </div>


### PR DESCRIPTION
Changes "out" to "our" in the subjects section; this was a typo.